### PR TITLE
fixed selector mesh bug

### DIFF
--- a/src/threeHelpers/SubjectManager.js
+++ b/src/threeHelpers/SubjectManager.js
@@ -13,6 +13,10 @@ class SubjectManager {
     while(this.meshArr[0]){
       this.scene.remove(this.meshArr.shift());
     }
+    if (this.selectedMesh){
+      this.scene.remove(this.selectedMesh);
+      this.selectedMesh = '';
+    }
   }
 
   resetState(newState){


### PR DESCRIPTION
Fixed bug in #26. 

Selector mesh now properly goes away when object is deleted.